### PR TITLE
Don't set -A header if not valid project

### DIFF
--- a/lib/osc/machete/torque_helper.rb
+++ b/lib/osc/machete/torque_helper.rb
@@ -64,7 +64,11 @@ class OSC::Machete::TorqueHelper
     # this will probably be both SUPERCOMPUTER CENTER SPECIFIC and must change
     # when we want to enable our users at OSC to specify which billable project
     # to bill against
-    headers[PBS::ATTR[:A]] = account_string || default_account_string
+    if account_string
+      headers[PBS::ATTR[:A]] = account_string
+    elsif account_string_valid_project?(default_account_string)
+      headers[PBS::ATTR[:A]] = default_account_string
+    end
 
     pbs_job.submit(file: script, headers: headers, qsub: true).id
   end
@@ -85,6 +89,10 @@ class OSC::Machete::TorqueHelper
   # @return [String] the project name that job submission should be billed against
   def default_account_string
     OSC::Machete::Process.new.groupname
+  end
+
+  def account_string_valid_project?(account_string)
+    /^P./ =~ account_string
   end
 
   # Performs a qstat request on a single job.

--- a/test/test_torque_helper.rb
+++ b/test/test_torque_helper.rb
@@ -194,9 +194,16 @@ class TestTorqueHelper < Minitest::Test
   end
 
   def test_default_account_string_used_in_qsub_during_submit_call
+    @shell.stubs(:default_account_string).returns("PZS3000")
+
     PBS::Job.any_instance.expects(:submit).with(has_entry(headers: {Account_Name: @shell.default_account_string})).returns(PBS::Job.new(conn: 'oakley', id: '1234598.oak-batch.osc.edu'))
     @shell.qsub(@script_oakley)
+
+    @shell.stubs(:default_account_string).returns("appl")
+    PBS::Job.any_instance.expects(:submit).with(has_entry(headers: {})).returns(PBS::Job.new(conn: 'oakley', id: '1234598.oak-batch.osc.edu'))
+    @shell.qsub(@script_oakley)
+
     PBS::Job.any_instance.unstub(:submit)
+    @shell.unstub(:default_account_string)
   end
-  
 end


### PR DESCRIPTION
Fixes https://github.com/AweSim-OSC/osc-machete/issues/103

Set the -A header only if account_string is passed in as an argument OR
if the default_account_string is a valid project.

If account_string is passed in, we don't validate it - we trust the
one invoking the method.

This is so that users with appl as the primary group submit without -A
being specified.
