### PR TITLE
WIP Global config

### DIFF
--- a/lib/osc/machete/torque_helper.rb
+++ b/lib/osc/machete/torque_helper.rb
@@ -18,9 +18,13 @@ class OSC::Machete::TorqueHelper
     :default => 'oak-batch.osc.edu'
   }
 
-  # Alias to initialize a new object.
-  def self.default
-    self::new()
+  class << self
+    #@!attribute default
+    #  @return [TorqueHelper] default TorqueHelper instance to use
+    attr_writer :default
+    def default
+      @default ||= self::new()
+    end
   end
 
   # Returns an OSC::Machete::Status ValueObject for a char

--- a/lib/osc/machete/torque_helper.rb
+++ b/lib/osc/machete/torque_helper.rb
@@ -126,26 +126,26 @@ class OSC::Machete::TorqueHelper
     # Common use case where trying to delete a job that is no longer in the system.
   end
 
-  private
-    def pbs(host: nil, id: nil, script: nil)
-      if host
-        # actually check if host is "oakley" i.e. a cluster key
-        host = HOSTS.fetch(host.to_s, host.to_s)
-      else
-        # try to determine host
-        key = host_from_pbsid(id) if id
-        key = host_from_script_pbs_header(script) if script && key.nil?
+  def pbs(host: nil, id: nil, script: nil)
+    if host
+      # actually check if host is "oakley" i.e. a cluster key
+      host = HOSTS.fetch(host.to_s, host.to_s)
+    else
+      # try to determine host
+      key = host_from_pbsid(id) if id
+      key = host_from_script_pbs_header(script) if script && key.nil?
 
-        host = HOSTS.fetch(key, HOSTS.fetch(:default))
-      end
-
-      pbs = PBS::Batch.new(
-        host: host,
-        lib: LIB,
-        bin: BIN
-      )
+      host = HOSTS.fetch(key, HOSTS.fetch(:default))
     end
 
+    pbs = PBS::Batch.new(
+      host: host,
+      lib: LIB,
+      bin: BIN
+    )
+  end
+
+  private
     # return the name of the host to use based on the pbs header
     # TODO: Think of a more efficient way to do this.
     def host_from_script_pbs_header(script)

--- a/test/test_torque_helper.rb
+++ b/test/test_torque_helper.rb
@@ -206,4 +206,24 @@ class TestTorqueHelper < Minitest::Test
     PBS::Batch.any_instance.unstub(:submit_script)
     @shell.unstub(:default_account_string)
   end
+
+  def test_pbs_default_host
+    s = @shell.pbs
+    assert_equal 'oak-batch.osc.edu', s.host
+    assert_equal OSC::Machete::TorqueHelper::LIB, s.lib.to_s
+    assert_equal OSC::Machete::TorqueHelper::BIN, s.bin.to_s
+  end
+
+  def test_pbs_host_variations
+    # you can use the cluster ids
+    assert_equal 'ruby-batch.osc.edu', @shell.pbs(host: 'ruby').host
+
+    # or you can use the host itself
+    assert_equal 'ruby-batch.osc.edu', @shell.pbs(host: 'ruby-batch.osc.edu').host
+    assert_equal '@ruby-batch', @shell.pbs(host: '@ruby-batch').host
+
+    assert_equal 'ruby-batch.osc.edu', @shell.pbs(id: '4567').host
+    assert_equal 'ruby-batch.osc.edu', @shell.pbs(script: @script_ruby).host
+    assert_equal 'oak-batch.osc.edu', @shell.pbs(script: @script_oakley).host
+  end
 end

--- a/test/test_torque_helper.rb
+++ b/test/test_torque_helper.rb
@@ -226,4 +226,29 @@ class TestTorqueHelper < Minitest::Test
     assert_equal 'ruby-batch.osc.edu', @shell.pbs(script: @script_ruby).host
     assert_equal 'oak-batch.osc.edu', @shell.pbs(script: @script_oakley).host
   end
+
+  def test_setting_default_torque_helper
+    d = OSC::Machete::TorqueHelper.default
+
+    assert_equal 'oak-batch.osc.edu', OSC::Machete::TorqueHelper.default.pbs.host
+
+    # this is an example of how you can quickly modify the default behavior of
+    # a TorqueHelper instance to provide a new host, id, and script
+    d2 = OSC::Machete::TorqueHelper.new
+    class << d2
+      def pbs(host: nil, id: nil, script: nil)
+        pbs = PBS::Batch.new(
+          host: "ruby-batch.osc.edu",
+          lib: LIB,
+          bin: BIN
+        )
+      end
+    end
+
+    OSC::Machete::TorqueHelper.default = d2
+
+    assert_equal 'ruby-batch.osc.edu', OSC::Machete::TorqueHelper.default.pbs.host
+
+    OSC::Machete::TorqueHelper.default = d
+  end
 end

--- a/test/test_torque_helper_live.rb
+++ b/test/test_torque_helper_live.rb
@@ -71,7 +71,7 @@ class TestTorqueHelperLive < Minitest::Test
 
       # Qstat it to make sure it's queued.
       live_status = torque.qstat(live_job)
-      assert_equal @job_state_queued, live_status
+      assert_includes OSC::Machete::Status.active_values, live_status
 
       # Delete it and assert true returned.
       live_delete_status = torque.qdel(live_job)
@@ -102,7 +102,7 @@ class TestTorqueHelperLive < Minitest::Test
 
       # Qstat it to make sure it's queued.
       live_status = torque.qstat(live_job)
-      assert_equal @job_state_queued, live_status
+      assert_includes OSC::Machete::Status.active_values, live_status
 
       # Delete it and assert true returned.
       live_delete_status = torque.qdel(live_job)
@@ -132,7 +132,7 @@ class TestTorqueHelperLive < Minitest::Test
 
       # Qstat it to make sure it's queued.
       live_status = torque.qstat(live_job)
-      assert_equal @job_state_queued, live_status
+      assert_includes OSC::Machete::Status.active_values, live_status
 
       # Delete it and assert true returned.
       live_delete_status = torque.qdel(live_job)
@@ -161,7 +161,7 @@ class TestTorqueHelperLive < Minitest::Test
 
       # Qstat it to make sure it's queued.
       live_status = torque.qstat(live_job)
-      assert_equal @job_state_queued, live_status
+      assert_includes OSC::Machete::Status.active_values, live_status
 
       # Delete it and assert true returned.
       live_delete_status = torque.qdel(live_job)


### PR DESCRIPTION
An option to using ood_cluster server objects for the TorqueHelper

A developer in the initializer would do something like this (from job constructor):

```ruby
OODClusters = OodAppkit.clusters.valid_hpc.to_h.select{|k,v| v.resource_mgr_server?}

OODClusters.each do |k,v|
  OSC::Machete::TorqueHelper.servers[k] = v.resource_mgr_server
  OSC::Machete::TorqueHelper.servers[v.resource_mgr_server.host] = v.resource_mgr_server
end
```

This would be a "fix" for legacy apps working on Magnum. It wouldn't be a replacement for an osc-machete + osc_machete_rails update (or replacement with ood_batch and ood_batch_rails).