### PR TITLE
Depend on newer Ruby and bundler

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,43 @@
+name: Publish Gem
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set version
+        id: version
+        run: echo ::set-output name=version::${GITHUB_REF#refs/*/v}
+
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Ruby using Bundler
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "2.7.1"
+          bundler-cache: true
+          bundler: "2.1.4"
+
+      - name: install gems
+        run: bundle install
+
+      - name: Setup Rubygems credentials
+        run: |
+          set +x
+          mkdir -p ~/.gem
+          cat << EOF > ~/.gem/credentials
+          ---
+          :rubygems_api_key: ${{ secrets.OSC_ROBOT_RUBYGEMS_TOKEN }}
+          EOF
+          chmod 0600 ~/.gem/credentials
+
+      - name: Publish Gem
+        run: |
+          bundle exec rake build
+          gem push pkg/osc-machete-${{ steps.version.outputs.version }}.gem

--- a/lib/osc/machete/version.rb
+++ b/lib/osc/machete/version.rb
@@ -1,6 +1,6 @@
 module OSC
   module Machete
     # The current gem version
-    VERSION = "1.2.2"
+    VERSION = "1.3.0"
   end
 end

--- a/lib/osc/machete/version.rb
+++ b/lib/osc/machete/version.rb
@@ -1,6 +1,6 @@
 module OSC
   module Machete
     # The current gem version
-    VERSION = "1.3.0"
+    VERSION = "2.0.0"
   end
 end

--- a/osc-machete.gemspec
+++ b/osc-machete.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = '~> 2.2'
+  spec.required_ruby_version = '>= 2.7'
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "mocha"
   spec.add_development_dependency "minitest", ">= 5.0"


### PR DESCRIPTION
Add Github workflow to publish

Copied workflow from ood_core and modified gem name.

Fixes #116 